### PR TITLE
Add Windows packaging workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,32 @@
+name: Build Windows app
+
+on:
+  push:
+    branches: [ work, main ]
+  pull_request:
+    branches: [ work, main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jurplel/install-qt-action@v3
+        with:
+          version: 6.5.3
+          host: windows
+          target: desktop
+          arch: win64_msvc2019_64
+      - name: Configure
+        run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Deploy Qt dependencies
+        run: |
+          windeployqt --dir build/package build/DemulEASY.exe
+          Compress-Archive -Path build/package/* -DestinationPath DemulEASY-win64.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: DemulEASY-win64
+          path: DemulEASY-win64.zip

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ DemulEasy is a straightforward, automated tool designed to simplify the configur
 - **Enhanced Features:**  
   Based on user feedback, future updates may include more advanced customization options and additional functionalities.
 
+## Continuous Integration
+
+A GitHub Actions workflow builds the project on Windows and packages the executable with its required Qt libraries. The workflow uploads a zipped artifact for download.
+
 ## Contributing
 
 Contributions are welcome! If you’d like to improve DemulEasy, please feel free to fork the repository and submit a pull request.


### PR DESCRIPTION
## Summary
- Build Windows app via GitHub Actions workflow using Qt 6 and Ninja
- Package executable with windeployqt and upload zipped artifact
- Document CI workflow in README

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_68b3c2c071f88332b7f51041e5d4923c