### PR TITLE
Add Windows packaging workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,32 @@
+name: Build Windows app
+
+on:
+  push:
+    branches: [ work, main ]
+  pull_request:
+    branches: [ work, main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jurplel/install-qt-action@v3
+        with:
+          version: 6.5.3
+          host: windows
+          target: desktop
+          arch: win64_msvc2019_64
+      - name: Configure
+        run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Deploy Qt dependencies
+        run: |
+          windeployqt --dir build/package build/DemulEASY.exe
+          Compress-Archive -Path build/package/* -DestinationPath DemulEASY-win64.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: DemulEASY-win64
+          path: DemulEASY-win64.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jurplel/install-qt-action@v3
+      - uses: jurplel/install-qt-action@v4
         with:
           version: 6.5.3
           host: windows

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,9 +18,9 @@ jobs:
           target: desktop
           arch: win64_msvc2019_64
       - name: Configure
-        run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${{ env.Qt6_DIR }}"
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build build
       - name: Deploy Qt dependencies
         run: |
           windeployqt --dir build/package build/DemulEASY.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jurplel/install-qt-action@v3
         with:
           version: 6.5.3
@@ -26,7 +26,7 @@ jobs:
           windeployqt --dir build/package build/DemulEASY.exe
           Compress-Archive -Path build/package/* -DestinationPath DemulEASY-win64.zip
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: DemulEASY-win64
           path: DemulEASY-win64.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set Qt path for Windows
-set(CMAKE_PREFIX_PATH "C:/Qt/6.8.1/mingw_64/lib/cmake")
-
 find_package(Qt6 COMPONENTS Widgets REQUIRED)
 
 set(PROJECT_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,54 +9,34 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+# Set Qt path for Windows
+set(CMAKE_PREFIX_PATH "C:/Qt/6.8.1/mingw_64/lib/cmake")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
 
 set(PROJECT_SOURCES
-        main.cpp
-        mainwindow.cpp
-        mainwindow.h
-        mainwindow.ui
+    main.cpp
+    mainwindow.cpp
+    mainwindow.h
+    mainwindow.ui
+    emulatorutils.cpp
+    emulatorutils.h
+    IniSyntaxHighlighter.cpp
+    IniSyntaxHighlighter.h
 )
 
-if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+if(QT_VERSION_MAJOR GREATER_EQUAL 6)
     qt_add_executable(DemulEASY
         MANUAL_FINALIZATION
         ${PROJECT_SOURCES}
     )
-# Define target properties for Android with Qt 6 as:
-#    set_property(TARGET DemulEASY APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
-#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
-# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
 else()
-    if(ANDROID)
-        add_library(DemulEASY SHARED
-            ${PROJECT_SOURCES}
-        )
-# Define properties for Android with Qt 5 after find_package() calls as:
-#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
-    else()
-        add_executable(DemulEASY
-            ${PROJECT_SOURCES}
-        )
-    endif()
+    add_executable(DemulEASY
+        ${PROJECT_SOURCES}
+    )
 endif()
 
 target_link_libraries(DemulEASY PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-
-# Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
-# If you are developing for iOS or macOS you should consider setting an
-# explicit, fixed bundle identifier manually though.
-if(${QT_VERSION} VERSION_LESS 6.1.0)
-  set(BUNDLE_ID_OPTION MACOSX_BUNDLE_GUI_IDENTIFIER com.example.DemulEASY)
-endif()
-set_target_properties(DemulEASY PROPERTIES
-    ${BUNDLE_ID_OPTION}
-    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
-    MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
-    MACOSX_BUNDLE TRUE
-    WIN32_EXECUTABLE TRUE
-)
 
 include(GNUInstallDirs)
 install(TARGETS DemulEASY

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ DemulEasy is a straightforward, automated tool designed to simplify the configur
 - **Enhanced Features:**  
   Based on user feedback, future updates may include more advanced customization options and additional functionalities.
 
+## Continuous Integration
+
+A GitHub Actions workflow builds the project on Windows and packages the executable with its required Qt libraries. The workflow uploads a zipped artifact for download.
+
 ## Contributing
 
 Contributions are welcome! If you’d like to improve DemulEasy, please feel free to fork the repository and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ DemulEasy is a straightforward, automated tool designed to simplify the configur
 
 A GitHub Actions workflow builds the project on Windows and packages the executable with its required Qt libraries. The workflow uploads a zipped artifact for download.
 
+## Building from Source
+
+To build the application locally, install the Qt 6 development libraries and point CMake to the Qt package directory, for example:
+
+```powershell
+cmake -S . -B build -DCMAKE_PREFIX_PATH="C:/Qt/6.5.3/msvc2019_64/lib/cmake"
+cmake --build build
+```
+
+Adjust the path to match your Qt installation. On macOS or Linux, use the appropriate Qt package path instead.
+
 ## Contributing
 
 Contributions are welcome! If you’d like to improve DemulEasy, please feel free to fork the repository and submit a pull request.


### PR DESCRIPTION
## Summary
- Build Windows app via GitHub Actions workflow using Qt 6 and Ninja
- Package executable with windeployqt and upload zipped artifact
- Document CI workflow in README
- Simplify CMake for Windows and include all project sources

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt6" due to missing Qt development libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c2c071f88332b7f51041e5d4923c