### PR TITLE
Add editable BAT tab and rename settings tab

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -50,15 +50,24 @@ private:
     void prepareDirectories(const QString &basePath, QDir &iniDir, QDir &batDir);
     void mapEmulator(QString &emulator, QString &demulShooterExe);
     QString mapRom(const QString &rom);
-    void createFiles(const QString &rom,
-                     const QString &emulatorInput,
-                     QString demulShooterExeInput,
-                     const QString &emulatorPath,
-                     const QString &romPath,
-                     const QString &qmamehookerPath,
-                     const QString &demulShooterPath,
-                     const QString &verbose,
-                     const QString &iniContent);
+      void createFiles(const QString &rom,
+                       const QString &emulatorInput,
+                       QString demulShooterExeInput,
+                       const QString &emulatorPath,
+                       const QString &romPath,
+                       const QString &qmamehookerPath,
+                       const QString &demulShooterPath,
+                       const QString &verbose,
+                       const QString &iniContent,
+                       const QString &batContent);
+      QString generateBatContent(const QString &rom,
+                                 const QString &emulatorInput,
+                                 QString demulShooterExeInput,
+                                 const QString &emulatorPath,
+                                 const QString &romPath,
+                                 const QString &qmamehookerPath,
+                                 const QString &demulShooterPath,
+                                 const QString &verbose);
     void updateLmpStartValue(int player, const QColor &color);
     bool safeReplaceLine(QStringList &lines, const QString &key, const QString &newLine);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -302,20 +302,34 @@
       <property name="usesScrollButtons">
        <bool>true</bool>
       </property>
-      <widget class="QWidget" name="tab_Generic">
-       <attribute name="title">
-        <string>Generic</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_Generic">
-        <item>
-         <widget class="QPlainTextEdit" name="plainTextEdit_Generic">
-          <property name="placeholderText">
-           <string>Enter generic configuration here...</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+     <widget class="QWidget" name="tab_Generic">
+      <attribute name="title">
+       <string>Settings ini</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_Generic">
+       <item>
+        <widget class="QPlainTextEdit" name="plainTextEdit_Generic">
+         <property name="placeholderText">
+          <string>Enter generic configuration here...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_Executable">
+      <attribute name="title">
+       <string>Executable bat</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_Executable">
+       <item>
+        <widget class="QPlainTextEdit" name="plainTextEdit_Bat">
+         <property name="placeholderText">
+          <string>Enter executable configuration here...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
       <widget class="QWidget" name="tab_OpenFIRE">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">


### PR DESCRIPTION
## Summary
- Rename the "Generic" tab to "Settings ini" and add a new "Executable bat" tab for viewing and editing batch files.
- Load existing BAT content or generate defaults, and export user-edited BAT text alongside INI files.

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b544309de483329097a1875e0c5eb5